### PR TITLE
v0.5.0 Fix Third Eye, camera reset config, and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.0] - 2026.08.19
+
+### Fixed
+
+- Fixed Third Eye cosmetic rendering issues
+
+### Added
+
+- Added config option for camera reset key. Default is `F3`.
+- Added config option for camera reset key hold time in seconds. Default is `1.5`, but it can be `0`.
+
 ## [0.4.0] - 2025.11.14
 
 Thanks to Isotope for this version! https://github.com/IsotopeReal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Third Eye cosmetic rendering issues
+- Fixed mirror in the lobby
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Fixed
 
 - Fixed Third Eye cosmetic rendering issues
+- Fixed player model showing on top of skeleton when dead
 - Fixed mirror in the lobby
+- Fixed ghost not hiding when toggling player model
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 - Press `F3` to enable the cinema camera, and fly around
 - Press `F3` again to toggle player movement or camera movement
-- Hold `F3` for 3 seconds to reset the camera position
+- Hold `F3` for 1.5 seconds to reset the camera position (Hold time is configurable)
+- Press `F4` to hide player when in cinema camera
 - Press `Escape` to exit the cinema camera
 
 Movement:

--- a/src/PeakCinema/PeakCinema.csproj
+++ b/src/PeakCinema/PeakCinema.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>com.github.megalon.peakcinema</AssemblyName>
     <AssemblyTitle>PeakCinema</AssemblyTitle>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -284,7 +284,20 @@ public partial class Plugin : BaseUnityPlugin
         }
         else
         {
-            customization.ShowAllRenderers();
+            customization._allRenderersHidden = false;
+            foreach (Renderer r in customization.refs.AllRenderers)
+            {
+                // Don't enable the accessory card if we're using the third eye
+                if (r.gameObject.name.Contains("Accesory Card") && customization.refs.thirdEye.activeSelf)
+                {
+                    r.enabled = false;
+                } else
+                {
+                    r.enabled = true;
+                }
+            }
+            customization.refs.hatTransform.gameObject.SetActive(value: true);
+
 
             customization.refs.mainRendererShadow.enabled = true;
             customization.refs.skirtShadow.enabled = true;

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -1,4 +1,4 @@
-using BepInEx;
+﻿using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
@@ -423,6 +423,16 @@ public partial class Plugin : BaseUnityPlugin
     {
         if (!__instance.IsLocal) return true;
         DeathLocation = __instance.refs.animationPositionTransform.position;
+
+        return true;
+    }
+
+    [HarmonyPatch(typeof(Mirror), "LateUpdate")]
+    [HarmonyPrefix]
+    static bool MirrorFix(Mirror __instance)
+    {
+        if (__instance.isInitialized && CinemaCamComponent != null)
+            __instance.mainCam = CinemaCamActive ? CinemaCamComponent : Camera.main;
 
         return true;
     }

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -30,6 +30,7 @@ public partial class Plugin : BaseUnityPlugin
     internal static Vector3 DeathLocation { get; private set; }
     internal static bool PlayerVisibilityToggled { get; private set; } = false;
     internal static bool InstanceOnLastUpdate { get; private set; } = false;
+    internal static bool GhostHidden { get; private set; } = false;
 
 
     private void Awake()
@@ -280,10 +281,58 @@ public partial class Plugin : BaseUnityPlugin
     private static void ApplyPlayerVisibility(bool cameraActive)
     {
         Character localCharacter = Character.AllCharacters.FirstOrDefault(c => c.IsLocal);
-        CharacterCustomization customization = localCharacter.refs.customization;
 
+        CharacterCustomization customization = localCharacter.refs.customization;
         if (customization == null) return;
 
+        // Ghost
+        if (localCharacter.IsGhost)
+        {
+            if (cameraActive && PlayerVisibilityToggled)
+            {
+                GhostHidden = true;
+
+                foreach (Renderer r in localCharacter.Ghost.PlayerRenderers)
+                {
+                    r.enabled = false;
+                }
+
+                foreach (Renderer r in localCharacter.Ghost.EyeRenderers)
+                {
+                    r.enabled = false;
+                }
+
+                localCharacter.Ghost.mouthRenderer.enabled = false;
+                localCharacter.Ghost.accessoryRenderer.enabled = false;
+                localCharacter.Ghost.thirdEye.gameObject.SetActive(false);
+            } 
+            else if (GhostHidden)
+            {
+                GhostHidden = false;
+
+                foreach (Renderer r in localCharacter.Ghost.PlayerRenderers)
+                {
+                    // Don't enable the accessory card if we're using the third eye
+                    if (r.gameObject.name.Contains("Accesory Card") && customization.refs.thirdEye.activeSelf)
+                        r.enabled = false;
+                    else
+                        r.enabled = true;
+                }
+
+                foreach (Renderer r in localCharacter.Ghost.EyeRenderers)
+                {
+                    r.enabled = true;
+                }
+
+                localCharacter.Ghost.mouthRenderer.enabled = true;
+                localCharacter.Ghost.accessoryRenderer.enabled = true;
+                localCharacter.Ghost.thirdEye.gameObject.SetActive(true);
+            }
+
+            return;
+        }
+
+        // Living player
         if (cameraActive && PlayerVisibilityToggled)
         {
             if (customization._allRenderersHidden) return;

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
@@ -458,9 +458,9 @@ public partial class Plugin : BaseUnityPlugin
         public PluginModConfig(ConfigFile config)
         {
             // General
-            toggleCinemaCamControlKey = config.Bind<KeyCode>("General", "Toggle Cinema Cam Control", KeyCode.F3, "Press to toggle Cinema Cam on/off.");
+            toggleCinemaCamControlKey = config.Bind<KeyCode>("General", "Toggle Cinema Cam Control", KeyCode.F3, "Press to enable cinema cam. Press again to flip between camera control and player control");
             resetCinemaCamKey = config.Bind<KeyCode>("General", "Reset Cinema Cam Position", KeyCode.F3, "Hold to reset camera position to the player position.");
-            initHoldTimer = config.Bind<float>("General", "Reset Hold Time", 1.5f, "Time in seconds to hold the camera reset key before it resets. Default 1.5, but can be 0!");
+            initHoldTimer = config.Bind<float>("General", "Reset Hold Time", 1.5f, "Time in seconds to hold the camera reset key before it resets. Can be set to 0.");
             exitCinemaCamKey = config.Bind<KeyCode>("General", "Exit Cinema Cam", KeyCode.Escape, "Exits the cinema camera and re-enables player input.");
             keyTogglePlayer = config.Bind<KeyCode>("General", "Toggle Player Visibility", KeyCode.F4, "Toggles your character model (body/head/cosmetics) on/off.");
 

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -26,7 +26,6 @@ public partial class Plugin : BaseUnityPlugin
     internal static bool CameraWasSpawned { get; private set; }
     internal static bool Smoothing { get; private set; } = true;
     internal static float HoldTimer { get; private set; }
-    internal static float InitHoldTimer { get; private set; } = 1.5f;
     internal static List<VoiceObscuranceFilter> VoiceFilters = new List<VoiceObscuranceFilter>();
     internal static Vector3 DeathLocation { get; private set; }
     internal static bool PlayerVisibilityToggled { get; private set; } = false;
@@ -42,7 +41,7 @@ public partial class Plugin : BaseUnityPlugin
 
         ModConfig = new PluginModConfig(Config);
 
-        HoldTimer = InitHoldTimer;
+        HoldTimer = ModConfig.initHoldTimer.Value;
     }
 
     [HarmonyPatch(typeof(VoiceObscuranceFilter), "Start")]
@@ -73,7 +72,7 @@ public partial class Plugin : BaseUnityPlugin
         }
 
         CameraWasSpawned = false;
-        HoldTimer = InitHoldTimer;
+        HoldTimer = ModConfig.initHoldTimer.Value;
         DeathLocation = Vector3.zero;
 
         if (HUD == null)
@@ -112,17 +111,29 @@ public partial class Plugin : BaseUnityPlugin
 
             ApplyPlayerVisibility(false);
         }
-        else if (Input.GetKey(ModConfig.toggleCinemaCamControlKey.Value))
+        
+        if (ModConfig.initHoldTimer.Value > 0)
         {
-            HoldTimer -= Time.deltaTime;
-            if (HoldTimer <= 0)
+            if (Input.GetKey(ModConfig.resetCinemaCamKey.Value))
+            {
+                HoldTimer -= Time.deltaTime;
+                if (HoldTimer <= 0)
+                {
+                    MoveCameraToPlayerPosition(__instance);
+                    if (!__instance.on) __instance.on = true;
+                    HoldTimer = -1;
+                }
+            }
+        } else
+        {
+            if (Input.GetKeyUp(ModConfig.resetCinemaCamKey.Value))
             {
                 MoveCameraToPlayerPosition(__instance);
                 if (!__instance.on) __instance.on = true;
-                HoldTimer = -1;
             }
         }
-        else if (Input.GetKeyUp(ModConfig.toggleCinemaCamControlKey.Value))
+
+        if (Input.GetKeyUp(ModConfig.toggleCinemaCamControlKey.Value))
         {
             if (!CinemaCamActive)
             {
@@ -136,7 +147,7 @@ public partial class Plugin : BaseUnityPlugin
                 __instance.on = !__instance.on;
             }
 
-            HoldTimer = InitHoldTimer;
+            HoldTimer = ModConfig.initHoldTimer.Value;
         }
 
         if (__instance.on)
@@ -419,6 +430,8 @@ public partial class Plugin : BaseUnityPlugin
     public class PluginModConfig
     {
         public readonly ConfigEntry<KeyCode> toggleCinemaCamControlKey;
+        public readonly ConfigEntry<KeyCode> resetCinemaCamKey;
+        public readonly ConfigEntry<float> initHoldTimer;
         public readonly ConfigEntry<KeyCode> exitCinemaCamKey;
         public readonly ConfigEntry<KeyCode> keyTogglePlayer;
 
@@ -445,7 +458,9 @@ public partial class Plugin : BaseUnityPlugin
         public PluginModConfig(ConfigFile config)
         {
             // General
-            toggleCinemaCamControlKey = config.Bind<KeyCode>("General", "Toggle Cinema Cam Control", KeyCode.F3, "Hold F3 to reset camera position to player, press F3 to toggle on/off.");
+            toggleCinemaCamControlKey = config.Bind<KeyCode>("General", "Toggle Cinema Cam Control", KeyCode.F3, "Press to toggle Cinema Cam on/off.");
+            resetCinemaCamKey = config.Bind<KeyCode>("General", "Reset Cinema Cam Position", KeyCode.F3, "Hold to reset camera position to the player position.");
+            initHoldTimer = config.Bind<float>("General", "Reset Hold Time", 1.5f, "Time in seconds to hold the camera reset key before it resets. Default 1.5, but can be 0!");
             exitCinemaCamKey = config.Bind<KeyCode>("General", "Exit Cinema Cam", KeyCode.Escape, "Exits the cinema camera and re-enables player input.");
             keyTogglePlayer = config.Bind<KeyCode>("General", "Toggle Player Visibility", KeyCode.F4, "Toggles your character model (body/head/cosmetics) on/off.");
 

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -30,6 +30,7 @@ public partial class Plugin : BaseUnityPlugin
     internal static List<VoiceObscuranceFilter> VoiceFilters = new List<VoiceObscuranceFilter>();
     internal static Vector3 DeathLocation { get; private set; }
     internal static bool PlayerVisibilityToggled { get; private set; } = false;
+    internal static bool InstanceOnLastUpdate { get; private set; } = false;
 
 
     private void Awake()
@@ -85,6 +86,7 @@ public partial class Plugin : BaseUnityPlugin
     [HarmonyPrefix]
     static bool CinemaCameraFix(CinemaCamera __instance)
     {
+        InstanceOnLastUpdate = __instance.on;
         HandlePlayerVisibilityInput();
 
         if (Input.GetKeyDown(ModConfig.exitCinemaCamKey.Value))
@@ -145,20 +147,23 @@ public partial class Plugin : BaseUnityPlugin
 
             ApplyPlayerVisibility(true);
 
-            __instance.ambience.parent = __instance.transform;
-            if ((bool)__instance.fog)
-                __instance.fog.gameObject.SetActive(false);
+            if (!InstanceOnLastUpdate)
+            {
+                if (!CameraWasSpawned)
+                    MoveCameraToPlayerPosition(__instance);
 
-            if ((bool)__instance.oldCam)
-                __instance.oldCam.gameObject.SetActive(false);
+                __instance.cam.gameObject.SetActive(true);
 
-            __instance.transform.parent = null;
-            __instance.cam.parent = null;
+                __instance.ambience.parent = __instance.transform;
+                if ((bool)__instance.fog)
+                    __instance.fog.gameObject.SetActive(false);
 
-            if (!CameraWasSpawned)
-                MoveCameraToPlayerPosition(__instance);
+                if ((bool)__instance.oldCam)
+                    __instance.oldCam.gameObject.SetActive(false);
 
-            __instance.cam.gameObject.SetActive(true);
+                __instance.transform.parent = null;
+                __instance.cam.parent = null;
+            }
 
             // FOV
             if (CinemaCamComponent != null)
@@ -240,7 +245,7 @@ public partial class Plugin : BaseUnityPlugin
             __instance.t = true;
             CameraWasSpawned = true;
         }
-        else
+        else if (InstanceOnLastUpdate && !__instance.on)
         {
             InputSystem.actions.Enable();
             ApplyPlayerVisibility(false);
@@ -264,14 +269,14 @@ public partial class Plugin : BaseUnityPlugin
     private static void ApplyPlayerVisibility(bool cameraActive)
     {
         Character localCharacter = Character.AllCharacters.FirstOrDefault(c => c.IsLocal);
-        CharacterCustomization customization = localCharacter?.refs?.customization;
+        CharacterCustomization customization = localCharacter.refs.customization;
 
         if (customization == null) return;
 
-        bool shouldBeHidden = cameraActive && PlayerVisibilityToggled;
-
-        if (shouldBeHidden)
+        if (cameraActive && PlayerVisibilityToggled)
         {
+            if (customization._allRenderersHidden) return;
+
             customization.HideAllRenderers();
 
             customization.refs.mainRendererShadow.enabled = false;
@@ -282,22 +287,18 @@ public partial class Plugin : BaseUnityPlugin
             customization.refs.medalRenderer.enabled = false;
             customization.refs.thirdEye.GetComponent<Renderer>().enabled = false;
         }
-        else
+        else if (customization._allRenderersHidden)
         {
             customization._allRenderersHidden = false;
             foreach (Renderer r in customization.refs.AllRenderers)
             {
                 // Don't enable the accessory card if we're using the third eye
                 if (r.gameObject.name.Contains("Accesory Card") && customization.refs.thirdEye.activeSelf)
-                {
                     r.enabled = false;
-                } else
-                {
+                else
                     r.enabled = true;
-                }
             }
             customization.refs.hatTransform.gameObject.SetActive(value: true);
-
 
             customization.refs.mainRendererShadow.enabled = true;
             customization.refs.skirtShadow.enabled = true;

--- a/src/PeakCinema/Plugin.cs
+++ b/src/PeakCinema/Plugin.cs
@@ -273,10 +273,26 @@ public partial class Plugin : BaseUnityPlugin
         if (shouldBeHidden)
         {
             customization.HideAllRenderers();
+
+            customization.refs.mainRendererShadow.enabled = false;
+            customization.refs.skirtShadow.enabled = false;
+            customization.refs.shortsShadow.enabled = false;
+            customization.refs.headShadow.enabled = false;
+            customization.refs.sashRenderer.enabled = false;
+            customization.refs.medalRenderer.enabled = false;
+            customization.refs.thirdEye.GetComponent<Renderer>().enabled = false;
         }
         else
         {
             customization.ShowAllRenderers();
+
+            customization.refs.mainRendererShadow.enabled = true;
+            customization.refs.skirtShadow.enabled = true;
+            customization.refs.shortsShadow.enabled = true;
+            customization.refs.headShadow.enabled = true;
+            customization.refs.sashRenderer.enabled = true;
+            customization.refs.medalRenderer.enabled = true;
+            customization.refs.thirdEye.GetComponent<Renderer>().enabled = true;
         }
     }
 


### PR DESCRIPTION
### Fixed

- Fixed Third Eye cosmetic rendering issues
- Fixed player model showing on top of skeleton when dead
- Fixed mirror in the lobby
- Fixed ghost not hiding when toggling player model

### Added

- Added config option for camera reset key. Default is `F3`. 
- Added config option for camera reset key hold time in seconds. Default is `1.5`, but it can be `0`.

Closes #14 
Closes #10 